### PR TITLE
Bump nixpkgs for Agda 2.6.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,7 +21,7 @@
     "mdbook-catppuccin": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-mdbook"
         ]
       },
       "locked": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696526028,
-        "narHash": "sha256-Psqo4j/KNvpk45MKscqdYk/N5lmrLKIV8x4ednfiqnY=",
+        "lastModified": 1699725108,
+        "narHash": "sha256-NTiPW4jRC+9puakU4Vi8WpFEirhp92kTOSThuZke+FA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7fdd1421774a52277fb56d64b26aaf7765e1b3fa",
+        "rev": "911ad1e67f458b6bcf0278fa85e33bb9924fed7e",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-mdbook": {
+      "locked": {
+        "lastModified": 1696526028,
+        "narHash": "sha256-Psqo4j/KNvpk45MKscqdYk/N5lmrLKIV8x4ednfiqnY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7fdd1421774a52277fb56d64b26aaf7765e1b3fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7fdd1421774a52277fb56d64b26aaf7765e1b3fa",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "mdbook-catppuccin": "mdbook-catppuccin",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-mdbook": "nixpkgs-mdbook"
       }
     },
     "systems": {


### PR DESCRIPTION
I kept the mdbook crates on the same version by pinning the checkout of nixpkgs we were using previously as `nixpkgs-mdbook`.

Both `make check` and `make website` work on my machine.